### PR TITLE
Update seqbuffer.js

### DIFF
--- a/lib/seqbuffer.js
+++ b/lib/seqbuffer.js
@@ -174,7 +174,7 @@ SeqBuffer.prototype = {
     }
 
     this._r += 10; // + 10 since field is 16 byte and only 6 are used for htype=1
-    return mac.toUpperCase().match(/../g).join('-');
+    return mac.toUpperCase().match(/../g).join(':');
   },
   //
   addBool: function() {


### PR DESCRIPTION
Real source (at least for me..) why MAC addresses used at static ip assignments didn't work with  ':' style but instead '-' at examples/server.js and console.log now prints MAC addresses with ':' instead earlier '-' as should be for more humans. 

If there was some reason to use '-' instead of ':' i am CLEARLY not aware of it.